### PR TITLE
corrected Pidgin to purple instead of pulse

### DIFF
--- a/rsync-homedir-excludes.txt
+++ b/rsync-homedir-excludes.txt
@@ -265,7 +265,7 @@ Thumbs.db
 #Other apps:
 
 # Pidgin
-.pulse/icons
+.purple/icons
 # Cached applets
 .guayadeque/cache.db
 .java/deployment/cache


### PR DESCRIPTION
i'm pretty sure Pidgin stores nothing inside `pulse` and if so, it is excluded via its dedicated line.