### PR TITLE
added containers storage and cache dir

### DIFF
--- a/rsync-homedir-excludes.txt
+++ b/rsync-homedir-excludes.txt
@@ -24,6 +24,7 @@
 #.grails_history
 #.kde/share/apps/nepomuk
 #.local/share/notbit
+#.local/share/containers
 #.local/libvirt
 #.vagrant
 #.vagrant.d

--- a/rsync-homedir-excludes.txt
+++ b/rsync-homedir-excludes.txt
@@ -18,6 +18,7 @@
 #.android
 #.AndroidStudio*/
 #Android/Sdk
+#.docker/machine
 #.gradle
 #.gvm
 #.grails/

--- a/rsync-homedir-excludes.txt
+++ b/rsync-homedir-excludes.txt
@@ -18,14 +18,12 @@
 #.android
 #.AndroidStudio*/
 #Android/Sdk
-#.docker/machine
 #.gradle
 #.gvm
 #.grails/
 #.grails_history
 #.kde/share/apps/nepomuk
 #.local/share/notbit
-#.local/share/containers
 #.local/libvirt
 #.vagrant
 #.vagrant.d
@@ -70,6 +68,9 @@
 #
 ## Unlocked Plasma Vaults
 #/Vaults
+## Docker
+#.docker/machine
+#.local/share/containers
 
 ################################################
 # These directories may definitely be excluded #


### PR DESCRIPTION
Podman (libpod) stores container cache and data in ~/.local/share/containers/{cache,storage} . IMO no need to back up.