### PR TITLE
Add new libvirt path

### DIFF
--- a/rsync-homedir-excludes.txt
+++ b/rsync-homedir-excludes.txt
@@ -25,6 +25,7 @@
 #.kde/share/apps/nepomuk
 #.local/share/notbit
 #.local/libvirt
+#.local/share/libvirt
 #.vagrant
 #.vagrant.d
 #.wine


### PR DESCRIPTION
libvirt now stores images in `~/.local/share/libvirt/`.