### PR TITLE
add LBRY files to exclude

### DIFF
--- a/rsync-homedir-excludes.txt
+++ b/rsync-homedir-excludes.txt
@@ -401,3 +401,7 @@ go/pkg/mod/cache
 
 # Geany IDE - socket file
 .config/geany/geany_socket_*
+
+# LBRY
+.config/lbry
+.local/share/lbry/lbrynet


### PR DESCRIPTION
LBRY is an awesome decentralized YouTube alternative.   But it will leave hundreds of gigs of temporary files that don't need to be backed up in random locations in the home directory.