### PR TITLE
Add exclude for the ".xsession-errors.old" file.

### DIFF
--- a/rsync-homedir-excludes.txt
+++ b/rsync-homedir-excludes.txt
@@ -121,6 +121,7 @@
 
 # Contains errors from the current graphical session
 .xsession-errors
+.xsession-errors.old
 .wayland-errors
 
 # Recently used files


### PR DESCRIPTION
The .old file also doesn't need to be backed up.