### PR TITLE
Instructions to incremental backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,17 @@ This project maintains a list of directories and files you probably do not need 
     # if it is all fine, actually perform your backup:
     rsync -aP --exclude-from=rsync-homedir-local.txt /home/$USER/ $BACKUPDIR
 
-    # makes your backup incremental (local transfer only, or with --whole-file option):
-    SNAPSHOT_DIR="$BACKUPDIR.$(date --iso-8601=seconds -u)"
-    cp -al $BACKUPDIR $SNAPSHOT_DIR
-
 You can edit the exclude file before execution:
 - All lines starting with a `#` are ignored by rsync, i.e. those directories will be backed up.
 - The syntax doesn't support comments at the end of a line yet.
 - At the start there is a section with directories that are probably not worth backing up. Uncomment those lines to exclude them as well.
+
+## Making incremental backups:
+When running locally or with the `--whole-file` option, rsync doesn't modify files but replaces them entirely.
+This allows us to snapshot the state of the backup directory at a certain point in time:
+
+    BACKUPDIR=/media/workspace/home/$USER/
+    SNAPSHOT_DIR="$BACKUPDIR.$(date --iso-8601=seconds -u)"
+    cp -al $BACKUPDIR $SNAPSHOT_DIR
+
+Next time you run your backup, the snapshot directory will be intact despite the changes rsync makes to the files in the backup directory.

--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ This project maintains a list of directories and files you probably do not need 
 
     # define a Backup directory (with trailing slash!)
     # some examples:
-    BACKUPDIR=/media/workspace/home/$USER/
-    BACKUPDIR=/media/$USER/linuxbackup/home/$USER/
-    BACKUPDIR=/media/$USER/USBSTICK/backup/home/$USER/
+    BACKUPDIR=/media/workspace/home/$USER
+    BACKUPDIR=/media/$USER/linuxbackup/home/$USER
+    BACKUPDIR=/media/$USER/USBSTICK/backup/home/$USER
 
     # first specify the "-n" parameter so rsync will simulate its operation. You should use this before you start:
-    rsync -naP --exclude-from=rsync-homedir-local.txt /home/$USER/ $BACKUPDIR
+    rsync -naP --exclude-from=rsync-homedir-local.txt /home/$USER/ $BACKUPDIR/
 
     # check for permission denied errors in your homedir:
-    rsync -naP --exclude-from=rsync-homedir-local.txt /home/$USER/ $BACKUPDIR|grep denied
+    rsync -naP --exclude-from=rsync-homedir-local.txt /home/$USER/ $BACKUPDIR/ | grep denied
 
     # if it is all fine, actually perform your backup:
-    rsync -aP --exclude-from=rsync-homedir-local.txt /home/$USER/ $BACKUPDIR
+    rsync -aP --exclude-from=rsync-homedir-local.txt /home/$USER/ $BACKUPDIR/
 
 You can edit the exclude file before execution:
 - All lines starting with a `#` are ignored by rsync, i.e. those directories will be backed up.
@@ -37,7 +37,7 @@ You can edit the exclude file before execution:
 When running locally or with the `--whole-file` option (for backups over SSH), rsync doesn't modify files but replaces them entirely. This allows us to create a snapshot directory (with hardlinks) with the state of the backup directory at a certain point in time.  
 Run this after finishing the `rsync` backup and it'll create a new snapshot:
 
-    BACKUPDIR=/media/workspace/home/$USER/
+    BACKUPDIR=/media/workspace/home/$USER
     SNAPSHOT_DIR="$BACKUPDIR.snapshot_$(date +'%Y-%m-%d_%H%M%S' -u)"
     cp -al $BACKUPDIR $SNAPSHOT_DIR
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This project maintains a list of directories and files you probably do not need 
     # if it is all fine, actually perform your backup:
     rsync -aP --exclude-from=rsync-homedir-local.txt /home/$USER/ $BACKUPDIR
 
-    # makes your backup incremental:
+    # makes your backup incremental (local transfer only, or with --whole-file option):
     SNAPSHOT_DIR="$BACKUPDIR.$(date --iso-8601=seconds -u)"
     cp -al $BACKUPDIR $SNAPSHOT_DIR
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ This project maintains a list of directories and files you probably do not need 
     # if it is all fine, actually perform your backup:
     rsync -aP --exclude-from=rsync-homedir-local.txt /home/$USER/ $BACKUPDIR
 
+    # makes your backup incremental:
+    SNAPSHOT_DIR="$BACKUPDIR.$(date --iso-8601=seconds -u)"
+    cp -al $BACKUPDIR $SNAPSHOT_DIR
+
 You can edit the exclude file before execution:
 - All lines starting with a `#` are ignored by rsync, i.e. those directories will be backed up.
 - The syntax doesn't support comments at the end of a line yet.

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ You can edit the exclude file before execution:
 - At the start there is a section with directories that are probably not worth backing up. Uncomment those lines to exclude them as well.
 
 ## Making incremental backups:
-When running locally or with the `--whole-file` option (for backups over SSH), rsync doesn't modify files but replaces them entirely.
-This allows us to create a snapshot directory (with hardlinks) with the state of the backup directory at a certain point in time:
+When running locally or with the `--whole-file` option (for backups over SSH), rsync doesn't modify files but replaces them entirely. This allows us to create a snapshot directory (with hardlinks) with the state of the backup directory at a certain point in time.  
+Run this after finishing the `rsync` backup and it'll create a new snapshot:
 
     BACKUPDIR=/media/workspace/home/$USER/
-    SNAPSHOT_DIR="$BACKUPDIR.snapsho_t$(date +'%Y-%m-%d_%H%M%S' -u)"
+    SNAPSHOT_DIR="$BACKUPDIR.snapshot_$(date +'%Y-%m-%d_%H%M%S' -u)"
     cp -al $BACKUPDIR $SNAPSHOT_DIR
 
-Next time you run your backup, the snapshot directory will be intact despite the changes rsync makes to the files in the backup directory.
+Next time you run your backup, the snapshot directory will be intact despite the changes rsync made to the files in the backup directory.

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ You can edit the exclude file before execution:
 - At the start there is a section with directories that are probably not worth backing up. Uncomment those lines to exclude them as well.
 
 ## Making incremental backups:
-When running locally or with the `--whole-file` option, rsync doesn't modify files but replaces them entirely.
-This allows us to snapshot the state of the backup directory at a certain point in time:
+When running locally or with the `--whole-file` option (for backups over SSH), rsync doesn't modify files but replaces them entirely.
+This allows us to create a snapshot directory (with hardlinks) with the state of the backup directory at a certain point in time:
 
     BACKUPDIR=/media/workspace/home/$USER/
-    SNAPSHOT_DIR="$BACKUPDIR.$(date --iso-8601=seconds -u)"
+    SNAPSHOT_DIR="$BACKUPDIR.snapsho_t$(date +'%Y-%m-%d_%H%M%S' -u)"
     cp -al $BACKUPDIR $SNAPSHOT_DIR
 
 Next time you run your backup, the snapshot directory will be intact despite the changes rsync makes to the files in the backup directory.


### PR DESCRIPTION
From `cp` man page:
```
   -l, --link
          hard link files instead of copying
```
I've been using this method for a long time. Snapshots use very little space if nothing changes.