### PR TITLE
adjust Electron Apps

### DIFF
--- a/rsync-homedir-excludes.txt
+++ b/rsync-homedir-excludes.txt
@@ -411,12 +411,12 @@ go/pkg/mod/cache
 .local/share/lbry/lbrynet
 
 # Electron Apps
-.config/*/blob_storage
-.config/*/Application Cache
-.config/*/Cache
-.config/*/CachedData
-.config/*/Code Cache
-.config/*/GPUCache
+.config/**/blob_storage
+.config/**/Application Cache
+.config/**/Cache
+.config/**/CachedData
+.config/**/Code Cache
+.config/**/GPUCache
 .var/app/**/blob_storage
 .var/app/**/Application Cache
 .var/app/**/Cache


### PR DESCRIPTION
To support Teams is in ~/.config/Microsoft/Microsoft\ Teams/* for example