### PR TITLE
Add .config/google-chrome/*/WebStorage/*/CacheStorage

### DIFF
--- a/rsync-homedir-excludes.txt
+++ b/rsync-homedir-excludes.txt
@@ -306,6 +306,7 @@ Thumbs.db
 .config/google-chrome/*/Application Cache
 .config/google-chrome/*/History Index *
 .config/google-chrome/*/Service Worker/CacheStorage
+.config/google-chrome/*/WebStorage/*/CacheStorage
 
 #Chromium:
 


### PR DESCRIPTION
Found google-chrome CacheStorage files in my backup that should be excluded