### PR TITLE
Update rsync-homedir-excludes.txt

### DIFF
--- a/rsync-homedir-excludes.txt
+++ b/rsync-homedir-excludes.txt
@@ -3,7 +3,7 @@
 # A list of files to exclude when backing up *nix home directories using rsync.
 #
 # Author: Ruben Barkow-Kuder <https://github.com/rubo77/rsync-homedir-excludes>
-# Version: 2019-11-30
+# Version: 2024-08-16
 #
 # #Usage:
 #    USER=<homedir username here>
@@ -14,6 +14,9 @@
 # directories, probably not worth a backup    #
 # (uncomment the files you don't need)        #
 ###############################################
+
+#temp*        # optional exclude all files/folders with temp in the beginning of there name
+#*cache*      # optional exclude all files/folders with cache in there name
 
 #.android
 #.AndroidStudio*/


### PR DESCRIPTION
added optional wildcard for all files and folder containing Cache and temp in the beginning of there name.


Small test with my home dir
```
Before
sent 7.603.161 bytes  received 687.143 bytes  84.165,52 bytes/sec
total size is 61.871.445.668  speedup is 7.463,11 (DRY RUN) 

After
sent 5.637.919 bytes  received 520.499 bytes  1.759.548,00 bytes/sec
total size is 53.959.177.129  speedup is 8.761,86 (DRY RUN)
```